### PR TITLE
Fixing sorting on second page

### DIFF
--- a/src/app/sampledata/sampledata-grid/sampledata-grid.component.html
+++ b/src/app/sampledata/sampledata-grid/sampledata-grid.component.html
@@ -8,16 +8,19 @@
       <button mat-button flex class="push-right-sm" [matTooltip]="'buttons.addItem' | translate" (click)="openDialog()">
         <mat-icon>add</mat-icon>
       </button>
-      <button mat-button flex class="push-right-sm" [disabled]="!selectedRow" [matTooltip]="'buttons.editItem' | translate" (click)="openEditDialog()">
+      <button mat-button flex class="push-right-sm" [disabled]="!selectedRow" [matTooltip]="'buttons.editItem' | translate"
+        (click)="openEditDialog()">
         <mat-icon>mode_edit</mat-icon>
       </button>
-      <button mat-button flex class="push-right-sm" [disabled]="!selectedRow" [matTooltip]="'buttons.deleteItem' | translate" (click)="openConfirm()">
+      <button mat-button flex class="push-right-sm" [disabled]="!selectedRow" [matTooltip]="'buttons.deleteItem' | translate"
+        (click)="openConfirm()">
         <mat-icon>delete</mat-icon>
       </button>
 
-      <form (ngSubmit)="getSampleData()" #filterForm="ngForm">
+      <form (ngSubmit)="filter()" #filterForm="ngForm">
         <td-expansion-panel label="Filters">
-          <div layout="row" class="pad-left-md pad-right-md" style="align-items:center; border-bottom: 1px solid lightgrey" flex>
+          <div layout="row" class="pad-left-md pad-right-md" style="align-items:center; border-bottom: 1px solid lightgrey"
+            flex>
             <div layout-xs="column" class="justify-space-around" style="align-items:center" hide-gt-xs flex>
               <mat-form-field color="accent">
                 <input matInput placeholder="Name" [(ngModel)]="searchTerms.name" name="name">
@@ -48,20 +51,15 @@
             </div>
           </div>
           <div class="align-right">
-            <button mat-button type="button" (click)="searchReset(filterForm)" class="text-upper property-text-bold">Clear filters</button>
+            <button mat-button type="button" (click)="searchReset(filterForm)" class="text-upper property-text-bold">Clear
+              filters</button>
             <button mat-raised-button type="submit" color="accent" class="text-upper property-text-bold">Apply filters</button>
           </div>
         </td-expansion-panel>
       </form>
       <mat-divider></mat-divider>
-      <td-data-table #dataTable
-        [data]="data"
-        [columns]="columns"
-        [sortable]="true"
-        [selectable]="true"
-        [multiple]="false"
-        (rowSelect)="selectEvent($event)"
-        (sortChange)="sort($event)">
+      <td-data-table #dataTable [data]="data" [columns]="columns" [sortable]="true" [selectable]="true" [multiple]="false"
+        (rowSelect)="selectEvent($event)" (sortChange)="sort($event)">
       </td-data-table>
       <div class="mat-padding" *ngIf="!dataTable.hasData" layout="row" layout-align="center center">
         <h3>No results to display.</h3>

--- a/src/app/sampledata/sampledata-grid/sampledata-grid.component.ts
+++ b/src/app/sampledata/sampledata-grid/sampledata-grid.component.ts
@@ -5,6 +5,7 @@ import {
   TdDialogService,
   IPageChangeEvent,
   ITdDataTableSortChangeEvent,
+  TdPagingBarComponent,
 } from '@covalent/core';
 import { MatDialogRef, MatDialog } from '@angular/material';
 import { Router } from '@angular/router';
@@ -20,13 +21,17 @@ import { Pageable } from '../../core/interfaces/pageable';
   styleUrls: ['./sampledata-grid.component.scss'],
 })
 export class SampleDataGridComponent implements OnInit {
+  @ViewChild('pagingBar')
+  pagingBar: TdPagingBarComponent;
+
   private pageable: Pageable = {
     pageSize: 8,
     pageNumber: 0,
   };
   private sorting: any[] = [];
 
-  @ViewChild('dataTable') dataTable: TdDataTableComponent;
+  @ViewChild('dataTable')
+  dataTable: TdDataTableComponent;
 
   data: any = [];
   columns: ITdDataTableColumn[] = [
@@ -82,7 +87,7 @@ export class SampleDataGridComponent implements OnInit {
         this.pageable.pageSize,
         this.pageable.pageNumber,
         this.searchTerms,
-        this.pageable.sort = this.sorting,
+        (this.pageable.sort = this.sorting),
       )
       .subscribe(
         (res: any) => {
@@ -234,6 +239,12 @@ export class SampleDataGridComponent implements OnInit {
         }
       });
   }
+
+  filter(): void {
+    this.getSampleData();
+    this.pagingBar.firstPage();
+  }
+
   searchReset(form: any): void {
     form.reset();
     this.getSampleData();


### PR DESCRIPTION
There was a strange bug so that when you were on a different page from the first one and you tried to search an element, the page was not refreshed automatically to the first one. 