### PR TITLE
Solving a duplicated call to the server

### DIFF
--- a/src/app/sampledata/sampledata-grid/sampledata-grid.component.ts
+++ b/src/app/sampledata/sampledata-grid/sampledata-grid.component.ts
@@ -241,7 +241,6 @@ export class SampleDataGridComponent implements OnInit {
   }
 
   filter(): void {
-    this.getSampleData();
     this.pagingBar.firstPage();
   }
 


### PR DESCRIPTION
When searching for an item, there was a duplicated call to the server. `this.pagingBar.firstPage();` already refreshes the data table, therefore we do not need the other method call.