### PR TITLE
devon4node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "~8.2.11",
     "@angular/platform-browser-dynamic": "~8.2.11",
     "@angular/router": "~8.2.11",
-    "@nestjsx/crud": "^4.2.0",
+    "@nestjsx/crud-request": "^4.2.0",
     "@ngx-translate/core": "11.0.1",
     "@ngx-translate/http-loader": "4.0.0",
     "core-js": "^2.5.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@angular/platform-browser": "~8.2.11",
     "@angular/platform-browser-dynamic": "~8.2.11",
     "@angular/router": "~8.2.11",
+    "@nestjsx/crud": "^4.2.0",
     "@ngx-translate/core": "11.0.1",
     "@ngx-translate/http-loader": "4.0.0",
     "core-js": "^2.5.4",


### PR DESCRIPTION
Related to [#1065](https://github.com/devonfw/tools-cobigen/pull/1065). 

In order to support [devon4node](https://github.com/devonfw/devon4node) we need to add this library on the list of dependencies. It is used for creating CRUD queries for the back end.