### PR TITLE
Corrected login payload which got changed due to linting

### DIFF
--- a/src/app/core/security/login.service.ts
+++ b/src/app/core/security/login.service.ts
@@ -35,8 +35,8 @@ export class LoginService {
     return this.http.post(
       this.bo.login(),
       {
-        username,
-        password,
+        j_username: username,
+        j_password: password,
       },
       options,
     );


### PR DESCRIPTION
Changed login payload from `username`, `password` to `j_username`, `j_password` as expected in the back end. It was changed due to linting rules earlier.